### PR TITLE
adjusting newBoardForm and Boardlist to handle empty cases

### DIFF
--- a/src/components/BoardList.js
+++ b/src/components/BoardList.js
@@ -35,6 +35,7 @@ const BoardList = ({ boardData, onBoardSelect, handleBoardDelete }) => {
     if (delboard) {
       handleBoardDelete(selectedBoard.id);
       setSelectedBoard(null);
+      onBoardSelect(null);
     }
   };
 

--- a/src/components/NewBoardForm.js
+++ b/src/components/NewBoardForm.js
@@ -34,6 +34,7 @@ const NewBoardForm = ({ handleNewBoardSubmit }) => {
     handleNewBoardSubmit(formData);
     // clear input field
     setFormData(kInitialFormData);
+    setInvalidForm({ title: true, owner: true });
   };
 
   if (showForm) {


### PR DESCRIPTION
adjusting newBoardForm and Boardlist to handle cases when there's no data
 - NewBoardForm: adds `setInvalidForm` to `handleFormSubmit`
 - BoardList: adds `onBoardSelect(null)` to `handleDeleteClick`